### PR TITLE
feat: add about dialog to run flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership for the entire repository.
+* @nikolareljin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- Feature: add an `About` dialog to `./run` with GitHub and LinkedIn profile links.
+
 ## 2026-02-12
 - Feature: add runtime abstraction for Ollama (`local` or `docker`) using shared helpers from `scripts/script-helpers/lib/ollama.sh`.
 - Feature: add Docker-backed Ollama flow with managed container startup, mounted model data dir, and runtime-aware pull/export/ps in `run/get/prompt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
-- Feature: add an `About` dialog to `./run` with GitHub and LinkedIn profile links.
+- Feature: add an `About` dialog to `./run` with project links plus GitHub and LinkedIn profile links.
+- Fix: keep `./run -i` bootstrap flow install-first so fresh machines do not require `dialog` before dependency setup.
 
 ## 2026-02-12
 - Feature: add runtime abstraction for Ollama (`local` or `docker`) using shared helpers from `scripts/script-helpers/lib/ollama.sh`.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example:
 ./run -r docker -m llama3 -p "Hello"
 ```
 
-In interactive mode, `./run` now opens with a small action menu that includes an `About` dialog with the GitHub and LinkedIn profile links.
+In interactive mode, `./run` now opens with a small action menu that includes an `About` dialog with project links plus the GitHub and LinkedIn profile links.
 
 If NO MODEL was selected, a selector will be displayed - so you can pick one that is available on Ollama:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example:
 ./run -r docker -m llama3 -p "Hello"
 ```
 
-In interactive mode, `./run` now opens with a small action menu that includes an `About` dialog with project links plus the GitHub and LinkedIn profile links.
+When run interactively without `-m` or `-p`, `./run` opens with a small action menu that includes an `About` dialog with project links plus the GitHub and LinkedIn profile links.
 
 If NO MODEL was selected, a selector will be displayed - so you can pick one that is available on Ollama:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example:
 ./run -r docker -m llama3 -p "Hello"
 ```
 
-When run interactively without `-m` or `-p`, `./run` opens with a small action menu that includes an `About` dialog with project links plus the GitHub and LinkedIn profile links.
+When run interactively without `-i`, `-m`, or `-p`, `./run` opens with a small action menu that includes an `About` dialog with project links plus the GitHub and LinkedIn profile links.
 
 If NO MODEL was selected, a selector will be displayed - so you can pick one that is available on Ollama:
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Example:
 ./run -r docker -m llama3 -p "Hello"
 ```
 
+In interactive mode, `./run` now opens with a small action menu that includes an `About` dialog with the GitHub and LinkedIn profile links.
+
 If NO MODEL was selected, a selector will be displayed - so you can pick one that is available on Ollama:
 
 <img width="1121" height="566" alt="image" src="https://github.com/user-attachments/assets/661c89a0-a6cb-46e7-8b8c-fdf89c95d95e" />

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -80,7 +80,7 @@ choose_start_action() {
                 show_about_dialog
                 ;;
             quit)
-                return 1
+                return 2
                 ;;
         esac
     done
@@ -144,9 +144,16 @@ if $run_install; then
     fi
 fi
 
-if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install && ! choose_start_action; then
-    print_error "Run cancelled."
-    exit 1
+if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
+    if ! choose_start_action; then
+        status=$?
+        if [[ $status -eq 2 ]]; then
+            print_info "Run cancelled."
+            exit 0
+        fi
+        print_error "Failed to open start menu."
+        exit "$status"
+    fi
 fi
 
 if [[ ! -f "$ENV_FILE" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -145,7 +145,9 @@ if $run_install; then
 fi
 
 if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
-    if ! choose_start_action; then
+    if choose_start_action; then
+        :
+    else
         status=$?
         if [[ $status -eq 2 ]]; then
             print_info "Run cancelled."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -45,7 +45,7 @@ help() { display_help "$0"; }
 show_about_dialog() {
     dialog_init
     check_if_dialog_installed
-    dialog --title "About ai-runner" --msgbox \
+    if ! dialog --title "About ai-runner" --msgbox \
 "ai-runner helps you select, run, and prompt local Ollama models from a dialog-based CLI.
 
 Projects
@@ -55,7 +55,9 @@ burn-iso:   https://github.com/nikolareljin/burn-iso
 Author profiles
 GitHub: https://github.com/nikolareljin
 LinkedIn: https://www.linkedin.com/in/nikolareljin" \
-        "$DIALOG_HEIGHT" "$DIALOG_WIDTH"
+        "$DIALOG_HEIGHT" "$DIALOG_WIDTH"; then
+        return 0
+    fi
 }
 
 choose_start_action() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -42,6 +42,45 @@ trap cleanup_screen EXIT
 
 help() { display_help "$0"; }
 
+show_about_dialog() {
+    dialog_init
+    check_if_dialog_installed
+    dialog --title "About ai-runner" --msgbox \
+"ai-runner helps you select, run, and prompt local Ollama models from a dialog-based CLI.
+
+Author profiles
+GitHub: https://github.com/nikolareljin
+LinkedIn: https://www.linkedin.com/in/nikolareljin" \
+        13 76
+}
+
+choose_start_action() {
+    local choice=""
+
+    while true; do
+        dialog_init
+        check_if_dialog_installed
+        if ! choice=$(dialog --stdout --title "ai-runner" --menu "Choose an action" "$DIALOG_HEIGHT" "$DIALOG_WIDTH" 10 \
+            "run" "Select a model and send a prompt" \
+            "about" "About" \
+            "quit" "Exit"); then
+            return 1
+        fi
+
+        case "$choice" in
+            run)
+                return 0
+                ;;
+            about)
+                show_about_dialog
+                ;;
+            quit)
+                return 1
+                ;;
+        esac
+    done
+}
+
 install_runner_dependencies() {
     if is_wsl; then
         print_info "WSL2 detected: installing common dependencies; Ollama CLI is expected on Windows host."
@@ -87,6 +126,11 @@ while getopts ":him:p:r:" opt; do
 done
 
 runtime_override="$(normalize_runtime_override "$runtime_override")"
+
+if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! choose_start_action; then
+    print_error "Run cancelled."
+    exit 1
+fi
 
 if $run_install; then
     if [[ "${SKIP_SETUP_DEPS:-0}" == "1" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -45,7 +45,7 @@ help() { display_help "$0"; }
 show_about_dialog() {
     dialog_init
     check_if_dialog_installed
-    if ! dialog --title "About ai-runner" --msgbox \
+    dialog --title "About ai-runner" --msgbox \
 "ai-runner helps you select, run, and prompt local Ollama models from a dialog-based CLI.
 
 Projects
@@ -55,9 +55,8 @@ burn-iso:   https://github.com/nikolareljin/burn-iso
 Author profiles
 GitHub: https://github.com/nikolareljin
 LinkedIn: https://www.linkedin.com/in/nikolareljin" \
-        "$DIALOG_HEIGHT" "$DIALOG_WIDTH"; then
-        return 0
-    fi
+        "$DIALOG_HEIGHT" "$DIALOG_WIDTH" || true
+    return 0
 }
 
 choose_start_action() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -48,10 +48,14 @@ show_about_dialog() {
     dialog --title "About ai-runner" --msgbox \
 "ai-runner helps you select, run, and prompt local Ollama models from a dialog-based CLI.
 
+Projects
+AgentVault: https://github.com/nikolareljin/agentvault
+burn-iso:   https://github.com/nikolareljin/burn-iso
+
 Author profiles
 GitHub: https://github.com/nikolareljin
 LinkedIn: https://www.linkedin.com/in/nikolareljin" \
-        13 76
+        "$DIALOG_HEIGHT" "$DIALOG_WIDTH"
 }
 
 choose_start_action() {
@@ -127,11 +131,6 @@ done
 
 runtime_override="$(normalize_runtime_override "$runtime_override")"
 
-if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! choose_start_action; then
-    print_error "Run cancelled."
-    exit 1
-fi
-
 if $run_install; then
     if [[ "${SKIP_SETUP_DEPS:-0}" == "1" ]]; then
         print_warning "SKIP_SETUP_DEPS=1 set; skipping setup-deps."
@@ -142,6 +141,11 @@ if $run_install; then
     else
         install_runner_dependencies
     fi
+fi
+
+if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install && ! choose_start_action; then
+    print_error "Run cancelled."
+    exit 1
 fi
 
 if [[ ! -f "$ENV_FILE" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -61,6 +61,7 @@ LinkedIn: https://www.linkedin.com/in/nikolareljin" \
 
 choose_start_action() {
     local choice=""
+    local status=0
 
     while true; do
         dialog_init
@@ -69,7 +70,11 @@ choose_start_action() {
             "run" "Select a model and send a prompt" \
             "about" "About" \
             "quit" "Exit"); then
-            return 1
+            status=$?
+            if [[ $status -eq 1 || $status -eq 255 ]]; then
+                return 2
+            fi
+            return "$status"
         fi
 
         case "$choice" in

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -66,10 +66,12 @@ choose_start_action() {
     while true; do
         dialog_init
         check_if_dialog_installed
-        if ! choice=$(dialog --stdout --title "ai-runner" --menu "Choose an action" "$DIALOG_HEIGHT" "$DIALOG_WIDTH" 10 \
+        if choice=$(dialog --stdout --title "ai-runner" --menu "Choose an action" "$DIALOG_HEIGHT" "$DIALOG_WIDTH" 10 \
             "run" "Select a model and send a prompt" \
             "about" "About" \
             "quit" "Exit"); then
+            :
+        else
             status=$?
             if [[ $status -eq 1 || $status -eq 255 ]]; then
                 return 2


### PR DESCRIPTION
# Summary
Add `About` "page" in the TUI mode

# Type of Change
- [x] feat
- [ ] fix
- [ ] chore
- [ ] docs
- [ ] refactor
- [ ] ci
- [ ] test

# Changes
- Display of the About page with info about other projects and links to them

# Checklist
- [x] Lint passes: `./scripts/lint.sh` (use `STRICT=1` to enforce)
- [x] Tests/examples run: `bash tests/test.sh`, `python3 tests/test-chat-python.py`, `node tests/test-chat-javascript.js`
- [x] Docs updated (README/AGENTS) if flags/flows changed
- [x] No secrets or large artifacts committed (.env, model files)

