### PR TITLE
fix: clarify get fallback model paths

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,7 @@ Closes #<issue-number> (or) Relates to #<issue-number>
 Paste dialog screenshots or CLI snippets for before/after.
 
 # Checklist
-- [ ] Lint passes: `./scripts/lint.sh` (use `STRICT=1` to enforce)
+- [ ] Lint passes: `./scripts/lint.sh` (install ShellCheck first; use `STRICT=1` to enforce)
 - [ ] Tests/examples run: `bash tests/test.sh`, `python3 tests/test-chat-python.py`, `node tests/test-chat-javascript.js`
 - [ ] Docs updated (README/AGENTS) if flags/flows changed
 - [ ] No secrets or large artifacts committed (.env, model files)
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
   - `node tests/test-chat-javascript.js`
   - `bash tests/test-chat-completions.sh`
 - Lint shell scripts: `./scripts/lint.sh` (set `STRICT=1` to fail on warnings). CI enforces strict ShellCheck on PRs.
+  - Install ShellCheck first if needed: `brew install shellcheck` or `sudo apt-get install -y shellcheck`
 
 ## Coding Style & Naming Conventions
 - Language: Bash. Use 4-space indentation and double quotes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Feature: add an `About` dialog to `./run` with project links plus GitHub and LinkedIn profile links.
 - Fix: keep `./run -i` bootstrap flow install-first so fresh machines do not require `dialog` before dependency setup.
 - Fix: clarify `./get` fallback success messages so the requested output directory and the actual Ollama runtime model-store path are reported separately when export is unavailable.
+- Tooling: add `tests/test.sh` as the documented shell smoke-test entrypoint.
+- Docs: clarify that `./scripts/lint.sh` requires ShellCheck to be installed locally.
 
 ## 2026-02-12
 - Feature: add runtime abstraction for Ollama (`local` or `docker`) using shared helpers from `scripts/script-helpers/lib/ollama.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Feature: add an `About` dialog to `./run` with project links plus GitHub and LinkedIn profile links.
 - Fix: keep `./run -i` bootstrap flow install-first so fresh machines do not require `dialog` before dependency setup.
+- Fix: clarify `./get` fallback success messages so the requested output directory and the actual Ollama runtime model-store path are reported separately when export is unavailable.
 
 ## 2026-02-12
 - Feature: add runtime abstraction for Ollama (`local` or `docker`) using shared helpers from `scripts/script-helpers/lib/ollama.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
 ## Unreleased
+- Fix: restore fully TUI-based model selection in `./run` and `./get` with no free-form model-name entry.
+- Fix: default interactive model browsing to official un-namespaced Ollama library models, sorted alphabetically, to avoid community duplicates in the main selector.
+- Fix: keep interactive selection loops in `./run` and `./get` so cancelling the size dialog returns to model selection instead of silently reusing a prior size.
+- Fix: show a loading indicator before opening the model selector and reuse a parsed model-menu cache for up to 30 minutes to speed up reopen flows.
+- Fix: route Ollama pull progress through a dialog gauge and prevent helper status output from corrupting `.env` values.
+
 - Feature: add an `About` dialog to `./run` with project links plus GitHub and LinkedIn profile links.
 - Fix: keep `./run -i` bootstrap flow install-first so fresh machines do not require `dialog` before dependency setup.
 - Fix: clarify `./get` fallback success messages so the requested output directory and the actual Ollama runtime model-store path are reported separately when export is unavailable.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ Examples:
 
 Notes:
 - The script creates the destination directory if it does not exist and extracts the archive there.
-- If you run without flags, it opens a dialog to choose either:
-  - indexed selection (model + size from model index), or
-  - manual entry (any Ollama model name/tag).
+- If you run without flags, it opens a dialog to browse official Ollama library models and pick a model and tag.
+- Indexed browsing refreshes the local model index from `/library` plus search slices, but the interactive selector defaults to official un-namespaced Ollama library models for a safer primary list.
 - Default destination remains `./models/<model>-<size>`.
 - To run a model with Ollama, prefer `./run` to select and pull a model (internally uses `ollama pull`), e.g.:
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Notes:
 - In Docker mode, pulled models are stored in `ollama_data_dir` (mounted into the container at `/root/.ollama`) so they are reusable across runs.
 - Optional: you can track a local path in `.env` via `model_path=./models/<name>` for your own workflows (not required by `./run`).
 
-# Lint and tests
+## Lint and tests
 
 Run the shell linter and smoke tests with:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ See [docs/INSTALL.md](docs/INSTALL.md) for the rest of the installation steps.
 
 Core scripts live in `scripts/`; use the root symlinks where possible.
 
+Linting requires ShellCheck:
+
+```sh
+brew install shellcheck
+# or
+sudo apt-get update && sudo apt-get install -y shellcheck
+```
+
 Install core dependencies before running:
 
 ```sh
@@ -140,6 +148,17 @@ Notes:
 - If a direct tar URL is unavailable (non-gzip response), the script falls back to runtime pull (`local` CLI or Docker container) and, when supported, exports an `.ollama` file in your destination.
 - In Docker mode, pulled models are stored in `ollama_data_dir` (mounted into the container at `/root/.ollama`) so they are reusable across runs.
 - Optional: you can track a local path in `.env` via `model_path=./models/<name>` for your own workflows (not required by `./run`).
+
+# Lint and tests
+
+Run the shell linter and smoke tests with:
+
+```sh
+STRICT=1 ./scripts/lint.sh
+bash tests/test.sh
+python3 tests/test-chat-python.py
+node tests/test-chat-javascript.js
+```
 
 ## get.sh help
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ If you already set up the model, size and have run the steps under `./run`, you 
 
 Use `./get` to download a model archive (tar.gz) to a local folder for offline use or analysis.
 If direct tar download is unavailable, it falls back to model pull via your selected runtime (`local` or `docker`).
+When the active Ollama build does not support `ollama export`, `./get` will report the runtime model-store path separately from the requested output directory, because no exported archive is written in that fallback case.
 
 Examples:
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -143,3 +143,4 @@ bash tests/test.sh [-h]
 
 Current coverage:
 - delegates to `tests/test-chat-completions.sh`
+- delegates to `tests/test-get-fallback-messages.sh`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -121,8 +121,24 @@ Usage:
 Environment:
 - `STRICT=1` to fail on warnings.
 
+Prerequisite:
+- Install ShellCheck first (`brew install shellcheck` or `sudo apt-get install -y shellcheck`).
+
 Example:
 
 ```sh
 STRICT=1 ./scripts/lint.sh
 ```
+
+## bash tests/test.sh
+
+Run the shell smoke-test wrapper for ai-runner.
+
+Usage:
+
+```sh
+bash tests/test.sh [-h]
+```
+
+Current coverage:
+- delegates to `tests/test-chat-completions.sh`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -76,7 +76,8 @@ Examples:
 ```
 
 Notes:
-- If run without flags, it opens a dialog to select from indexed models or enter any model manually.
+- If run without flags, it opens a dialog to browse official Ollama library models and pick a model and tag.
+- The indexed catalog is refreshed from the Ollama library plus search slices, while the interactive selector defaults to official un-namespaced library models.
 - In non-interactive mode, use `-m model:tag` when you need a specific tag/size.
 - If a direct tar URL is unavailable, it falls back to runtime pull (`local` CLI or Docker container) and then attempts to export to a local file when supported.
 

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -162,10 +162,9 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
-    if menu_cache_file="$(require_model_menu_cache_file "$json_file")"; then
-        :
-    else
-        exit $?
+    if ! menu_cache_file="$(require_model_menu_cache_file "$json_file")"; then
+        status=$?
+        exit "$status"
     fi
 
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -31,6 +31,42 @@ json_file=""
 
 help() { display_help "$0"; }
 
+show_model_catalog_loading_indicator() {
+    local message="${1:-Fetching Ollama model catalog...
+Preparing selection dialog.}"
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        return 0
+    fi
+    dialog_init
+    check_if_dialog_installed || return 0
+    dialog --title "ai-runner" --infobox "$message" 8 60
+    sleep 0.2
+}
+
+prepare_model_menu_cache_with_indicator() {
+    local json_file="$1"
+    local cache_file=""
+
+    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
+    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+        printf '%s
+' "$cache_file"
+        return 0
+    fi
+
+    while true; do
+        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
+Building model selection cache."
+        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
+        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+            printf '%s
+' "$cache_file"
+            return 0
+        fi
+        sleep 0.2
+    done
+}
+
 sanitize_filename_component() {
     local value="$1"
 
@@ -112,74 +148,32 @@ import tarfile
 
 archive = sys.argv[1]
 try:
-    with tarfile.open(archive, "r:gz") as tf:
-        for member in tf:
-            original_name = member.name
-            name = original_name
-            while name.startswith("./"):
-                name = name[2:]
-            if not name:
-                raise ValueError(f"unsafe archive entry: {member.name}")
-            p = pathlib.PurePosixPath(name)
-            if p.is_absolute() or ".." in p.parts:
-                raise ValueError(f"unsafe archive path: {member.name}")
-            if member.issym() or member.islnk():
-                raise ValueError(f"unsafe link entry: {member.name}")
-            if member.ischr() or member.isblk() or member.isfifo():
-                raise ValueError(f"unsafe special entry: {member.name}")
-            if hasattr(member, "issock") and member.issock():
-                raise ValueError(f"unsafe special entry: {member.name}")
-except Exception as exc:
-    print(str(exc), file=sys.stderr)
-    sys.exit(1)
-PY
-    then
-        print_error "Archive safety validation failed for: $archive_path"
-        return 1
-    fi
-
-    return 0
-}
-
 get_select_model_any() {
     local json_file="$1"
     local current_model="${2:-}"
     local current_size="${3:-latest}"
-    local mode model_value size_value
+    local model_value size_value status
 
-    dialog_init
-    check_if_dialog_installed
-
-    if ! mode=$(dialog --stdout --menu "Select model source" "$DIALOG_HEIGHT" "$DIALOG_WIDTH" 10 \
-        "indexed" "Choose from indexed Ollama models" \
-        "manual" "Enter any model name manually"); then
-        print_error "Model selection cancelled."
-        return 1
-    fi
-
-    if [[ "$mode" == "indexed" ]]; then
+    while true; do
         model_value="$(ollama_dialog_select_model "$json_file" "$current_model")" || return 1
-        size_value="$(ollama_dialog_select_size "$json_file" "$model_value" "$current_size")" || return 1
-        printf '%s\n%s\n' "$model_value" "$size_value"
-        return 0
-    fi
-
-    model_value="$(get_value "Model Name" "Enter any Ollama model name (example: deepseek-ocr)" "$current_model")" || return 1
-    model_value="$(printf '%s' "$model_value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    if [[ -z "$model_value" ]]; then
-        print_error "Model name cannot be empty."
-        return 1
-    fi
-
-    size_value="$(get_value "Model Size/Tag" "Enter size/tag (example: 3b). Use latest for default." "$current_size")" || return 1
-    size_value="$(printf '%s' "${size_value:-latest}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    [[ -z "$size_value" ]] && size_value="latest"
-    printf '%s\n%s\n' "$model_value" "$size_value"
+        if size_value="$(ollama_dialog_select_size "$json_file" "$model_value" "$current_size")"; then
+            printf '%s\n%s\n' "$model_value" "$size_value"
+            return 0
+        fi
+        status=$?
+        if [[ $status -eq 2 ]]; then
+            current_model="$model_value"
+            continue
+        fi
+        return "$status"
+    done
 }
 
 model=""
 size=""
 url=""
+dir=""
+runtime_override=""
 dir=""
 runtime_override=""
 
@@ -214,6 +208,7 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
+    export OLLAMA_MODEL_MENU_CACHE_FILE="$(prepare_model_menu_cache_with_indicator "$json_file")"
 
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -162,16 +162,11 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
-    if ! menu_cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")"; then
-        status=$?
-        print_error "Failed to prepare model menu cache."
-        exit "$status"
+    if menu_cache_file="$(require_model_menu_cache_file "$json_file")"; then
+        :
+    else
+        exit $?
     fi
-    if [[ -z "$menu_cache_file" ]]; then
-        print_error "Model menu cache path is empty."
-        exit 1
-    fi
-    export OLLAMA_MODEL_MENU_CACHE_FILE="$menu_cache_file"
 
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -101,7 +101,7 @@ PY
     return 0
 }
 
-get_select_model_any() {
+get_select_model_via_dialog() {
     local json_file="$1"
     local current_model="${2:-}"
     local current_size="${3:-latest}"
@@ -110,6 +110,10 @@ get_select_model_any() {
     while true; do
         if ! model_value="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
             status=$?
+            if [[ $status -eq 2 ]]; then
+                print_info "Model selection cancelled by user."
+                return 1
+            fi
             return "$status"
         fi
         if size_value="$(ollama_dialog_select_size "$json_file" "$model_value" "$current_size")"; then
@@ -172,7 +176,7 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
     [[ -n "$size" ]] && current_size="$size"
-    if ! selection_output="$(get_select_model_any "$json_file" "$current_model" "$current_size")"; then
+    if ! selection_output="$(get_select_model_via_dialog "$json_file" "$current_model" "$current_size")"; then
         exit 1
     fi
     mapfile -t selection_lines <<< "$selection_output"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -176,7 +176,7 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         if [[ $status -eq 2 ]]; then
             exit 0
         fi
-        exit 1
+        exit "$status"
     fi
     mapfile -t selection_lines <<< "$selection_output"
     if [[ "${#selection_lines[@]}" -lt 2 ]]; then

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -159,7 +159,15 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
-    export OLLAMA_MODEL_MENU_CACHE_FILE="$(prepare_model_menu_cache_with_indicator "$json_file")"
+    if ! menu_cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")"; then
+        print_error "Failed to prepare model menu cache."
+        exit 1
+    fi
+    if [[ -z "$menu_cache_file" ]]; then
+        print_error "Model menu cache path is empty."
+        exit 1
+    fi
+    export OLLAMA_MODEL_MENU_CACHE_FILE="$menu_cache_file"
 
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -42,6 +42,46 @@ sanitize_filename_component() {
     printf "%s\n" "$value"
 }
 
+normalize_compare_path() {
+    local raw_path="$1"
+    local normalized=""
+
+    if [[ -z "$raw_path" ]]; then
+        printf "\n"
+        return 0
+    fi
+
+    if command -v realpath >/dev/null 2>&1; then
+        if normalized="$(realpath -m -- "$raw_path" 2>/dev/null)"; then
+            printf "%s\n" "$normalized"
+            return 0
+        fi
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        if normalized="$(python3 - "$raw_path" <<'PY'
+import os
+import sys
+
+print(os.path.normpath(os.path.abspath(sys.argv[1])))
+PY
+        )"; then
+            printf "%s\n" "$normalized"
+            return 0
+        fi
+    fi
+
+    normalized="${raw_path%/}"
+    [[ -z "$normalized" ]] && normalized="/"
+    printf "%s\n" "$normalized"
+}
+
+paths_match_for_message() {
+    local left="$1"
+    local right="$2"
+    [[ "$(normalize_compare_path "$left")" == "$(normalize_compare_path "$right")" ]]
+}
+
 validate_tar_archive_safety() {
     local archive_path="$1"
     if ! command -v python3 >/dev/null 2>&1; then
@@ -275,14 +315,14 @@ if [[ -n "$model" ]]; then
         else
             if [[ "$runtime" == "docker" ]]; then
                 cache_dir="$(ollama_runtime_data_dir "$ENV_FILE")"
-                if [[ "$dir" == "$cache_dir" ]]; then
+                if paths_match_for_message "$dir" "$cache_dir"; then
                     print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the runtime model store is ${cache_dir}."
                 else
                     print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the Docker runtime store at ${cache_dir}."
                 fi
             else
                 cache_dir="$(ollama_runtime_local_models_dir "$ENV_FILE")"
-                if [[ "$dir" == "$cache_dir" ]]; then
+                if paths_match_for_message "$dir" "$cache_dir"; then
                     print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the local runtime model store is ${cache_dir}."
                 else
                     print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the local Ollama model store at ${cache_dir}."

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -108,7 +108,9 @@ get_select_model_via_dialog() {
     local model_value size_value status
 
     while true; do
-        if ! model_value="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+        if model_value="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+            :
+        else
             status=$?
             if [[ $status -eq 2 ]]; then
                 print_info "Model selection cancelled by user."
@@ -173,7 +175,9 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
     [[ -n "$size" ]] && current_size="$size"
-    if ! selection_output="$(get_select_model_via_dialog "$json_file" "$current_model" "$current_size")"; then
+    if selection_output="$(get_select_model_via_dialog "$json_file" "$current_model" "$current_size")"; then
+        :
+    else
         status=$?
         if [[ $status -eq 2 ]]; then
             exit 0

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -108,7 +108,10 @@ get_select_model_any() {
     local model_value size_value status
 
     while true; do
-        model_value="$(ollama_dialog_select_model "$json_file" "$current_model")" || return 1
+        if ! model_value="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+            status=$?
+            return "$status"
+        fi
         if size_value="$(ollama_dialog_select_size "$json_file" "$model_value" "$current_size")"; then
             printf '%s\n%s\n' "$model_value" "$size_value"
             return 0
@@ -160,8 +163,9 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
     if ! menu_cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")"; then
+        status=$?
         print_error "Failed to prepare model menu cache."
-        exit 1
+        exit "$status"
     fi
     if [[ -z "$menu_cache_file" ]]; then
         print_error "Model menu cache path is empty."

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -114,6 +114,7 @@ get_select_model_via_dialog() {
                 print_info "Model selection cancelled by user."
                 return 2
             fi
+            print_error "Failed to select model."
             return "$status"
         fi
         if size_value="$(ollama_dialog_select_size "$json_file" "$model_value" "$current_size")"; then
@@ -125,6 +126,7 @@ get_select_model_via_dialog() {
             current_model="$model_value"
             continue
         fi
+        print_error "Failed to select model size."
         return "$status"
     done
 }

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -112,7 +112,7 @@ get_select_model_via_dialog() {
             status=$?
             if [[ $status -eq 2 ]]; then
                 print_info "Model selection cancelled by user."
-                return 1
+                return 2
             fi
             return "$status"
         fi
@@ -166,17 +166,16 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
-    if require_model_menu_cache_file "$json_file" >/dev/null; then
-        :
-    else
-        status=$?
-        exit "$status"
-    fi
+    require_model_menu_cache_file "$json_file" >/dev/null || exit "$?"
 
     current_model="${model:-$(resolve_env_value "model" "" "$ENV_FILE")}"
     current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
     [[ -n "$size" ]] && current_size="$size"
     if ! selection_output="$(get_select_model_via_dialog "$json_file" "$current_model" "$current_size")"; then
+        status=$?
+        if [[ $status -eq 2 ]]; then
+            exit 0
+        fi
         exit 1
     fi
     mapfile -t selection_lines <<< "$selection_output"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -162,7 +162,9 @@ if [[ -t 0 && -t 1 && -z "$model" && -z "$url" ]]; then
         print_info "Model index not found. Preparing..."
         json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
     fi
-    if ! menu_cache_file="$(require_model_menu_cache_file "$json_file")"; then
+    if require_model_menu_cache_file "$json_file" >/dev/null; then
+        :
+    else
         status=$?
         exit "$status"
     fi

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -275,10 +275,18 @@ if [[ -n "$model" ]]; then
         else
             if [[ "$runtime" == "docker" ]]; then
                 cache_dir="$(ollama_runtime_data_dir "$ENV_FILE")"
-                print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; model is available in ${cache_dir}."
+                if [[ "$dir" == "$cache_dir" ]]; then
+                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the runtime model store is ${cache_dir}."
+                else
+                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the Docker runtime store at ${cache_dir}."
+                fi
             else
                 cache_dir="$(ollama_runtime_local_models_dir "$ENV_FILE")"
-                print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; model is available in ${cache_dir}."
+                if [[ "$dir" == "$cache_dir" ]]; then
+                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the local runtime model store is ${cache_dir}."
+                else
+                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the local Ollama model store at ${cache_dir}."
+                fi
             fi
             exit 0
         fi

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -31,42 +31,6 @@ json_file=""
 
 help() { display_help "$0"; }
 
-show_model_catalog_loading_indicator() {
-    local message="${1:-Fetching Ollama model catalog...
-Preparing selection dialog.}"
-    if [[ ! -t 0 || ! -t 1 ]]; then
-        return 0
-    fi
-    dialog_init
-    check_if_dialog_installed || return 0
-    dialog --title "ai-runner" --infobox "$message" 8 60
-    sleep 0.2
-}
-
-prepare_model_menu_cache_with_indicator() {
-    local json_file="$1"
-    local cache_file=""
-
-    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
-    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
-        printf '%s
-' "$cache_file"
-        return 0
-    fi
-
-    while true; do
-        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
-Building model selection cache."
-        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
-        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
-            printf '%s
-' "$cache_file"
-            return 0
-        fi
-        sleep 0.2
-    done
-}
-
 sanitize_filename_component() {
     local value="$1"
 
@@ -76,46 +40,6 @@ sanitize_filename_component() {
         value="unknown"
     fi
     printf "%s\n" "$value"
-}
-
-normalize_compare_path() {
-    local raw_path="$1"
-    local normalized=""
-
-    if [[ -z "$raw_path" ]]; then
-        printf "\n"
-        return 0
-    fi
-
-    if command -v realpath >/dev/null 2>&1; then
-        if normalized="$(realpath -m -- "$raw_path" 2>/dev/null)"; then
-            printf "%s\n" "$normalized"
-            return 0
-        fi
-    fi
-
-    if command -v python3 >/dev/null 2>&1; then
-        if normalized="$(python3 - "$raw_path" <<'PY'
-import os
-import sys
-
-print(os.path.normpath(os.path.abspath(sys.argv[1])))
-PY
-        )"; then
-            printf "%s\n" "$normalized"
-            return 0
-        fi
-    fi
-
-    normalized="${raw_path%/}"
-    [[ -z "$normalized" ]] && normalized="/"
-    printf "%s\n" "$normalized"
-}
-
-paths_match_for_message() {
-    local left="$1"
-    local right="$2"
-    [[ "$(normalize_compare_path "$left")" == "$(normalize_compare_path "$right")" ]]
 }
 
 validate_tar_archive_safety() {
@@ -148,6 +72,35 @@ import tarfile
 
 archive = sys.argv[1]
 try:
+    with tarfile.open(archive, "r:gz") as tf:
+        for member in tf:
+            original_name = member.name
+            name = original_name
+            while name.startswith("./"):
+                name = name[2:]
+            if not name:
+                raise ValueError(f"unsafe archive entry: {member.name}")
+            p = pathlib.PurePosixPath(name)
+            if p.is_absolute() or ".." in p.parts:
+                raise ValueError(f"unsafe archive path: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"unsafe link entry: {member.name}")
+            if member.ischr() or member.isblk() or member.isfifo():
+                raise ValueError(f"unsafe special entry: {member.name}")
+            if hasattr(member, "issock") and member.issock():
+                raise ValueError(f"unsafe special entry: {member.name}")
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
+PY
+    then
+        print_error "Archive safety validation failed for: $archive_path"
+        return 1
+    fi
+
+    return 0
+}
+
 get_select_model_any() {
     local json_file="$1"
     local current_model="${2:-}"
@@ -172,8 +125,6 @@ get_select_model_any() {
 model=""
 size=""
 url=""
-dir=""
-runtime_override=""
 dir=""
 runtime_override=""
 
@@ -310,18 +261,10 @@ if [[ -n "$model" ]]; then
         else
             if [[ "$runtime" == "docker" ]]; then
                 cache_dir="$(ollama_runtime_data_dir "$ENV_FILE")"
-                if paths_match_for_message "$dir" "$cache_dir"; then
-                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the runtime model store is ${cache_dir}."
-                else
-                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the Docker runtime store at ${cache_dir}."
-                fi
+                print_success "$(ollama_export_unavailable_message "$runtime" "$dir" "$cache_dir")"
             else
                 cache_dir="$(ollama_runtime_local_models_dir "$ENV_FILE")"
-                if paths_match_for_message "$dir" "$cache_dir"; then
-                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; the local runtime model store is ${cache_dir}."
-                else
-                    print_success "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${dir}. The model is available through the local Ollama model store at ${cache_dir}."
-                fi
+                print_success "$(ollama_export_unavailable_message "$runtime" "$dir" "$cache_dir")"
             fi
             exit 0
         fi

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -154,7 +154,13 @@ PY
 paths_match_for_message() {
     local left="$1"
     local right="$2"
-    [[ "$(normalize_compare_path "$left")" == "$(normalize_compare_path "$right")" ]]
+    local left_norm
+    local right_norm
+
+    left_norm="$(normalize_compare_path "$left")"
+    right_norm="$(normalize_compare_path "$right")"
+
+    [[ "$left_norm" == "$right_norm" ]]
 }
 
 ollama_export_unavailable_message() {

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -144,6 +144,7 @@ prepare_model_menu_cache_with_indicator() {
     local ttl_seconds="$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"
     local cache_path=""
     local attempt=1
+    local last_status=1
 
     max_attempts="$(coerce_positive_integer "$max_attempts" "5")"
     ttl_seconds="$(coerce_positive_integer "$ttl_seconds" "1800")"
@@ -159,7 +160,10 @@ prepare_model_menu_cache_with_indicator() {
         local loading_message=$'Fetching Ollama model catalog...\nBuilding model selection cache.'
 
         show_model_catalog_loading_indicator "$loading_message"
-        if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_path")"; then
+        if prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_path")"; then
+            :
+        else
+            last_status=$?
             if (( attempt < max_attempts )); then
                 sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
             fi
@@ -170,13 +174,14 @@ prepare_model_menu_cache_with_indicator() {
             printf '%s\n' "$prepared_cache"
             return 0
         fi
+        last_status=1
         if (( attempt < max_attempts )); then
             sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
         fi
         attempt=$((attempt + 1))
     done
 
-    return 1
+    return "$last_status"
 }
 
 normalize_compare_path() {

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -182,7 +182,6 @@ normalize_compare_path() {
     local parent_dir=""
     local base_name=""
     local dir_norm=""
-    local joined=""
     local -a parts=()
     local -a resolved=("")
     local part=""
@@ -251,8 +250,8 @@ PY2
     if (( ${#resolved[@]} == 1 )); then
         normalized="/"
     else
-        joined="${resolved[*]:1}"
-        normalized="/${joined// /\/}"
+        local IFS='/'
+        normalized="/${resolved[*]:1}"
     fi
 
     printf '%s\n' "$normalized"

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -26,6 +26,10 @@ print_success() { printf "OK: %s\n" "$1"; }
 print_warning() { printf "WARN: %s\n" "$1"; }
 print_error() { printf "ERROR: %s\n" "$1" >&2; }
 
+OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS="${OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS:-1800}"
+OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS="${OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS:-0.2}"
+OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS="${OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS:-5}"
+
 prompt_install_script_helpers() {
     if [[ -f "$HELPERS_PATH" ]]; then
         return 0
@@ -80,12 +84,12 @@ Preparing selection dialog.}"
 
 prepare_model_menu_cache_with_indicator() {
     local json_file="$1"
-    local max_attempts="${2:-5}"
+    local max_attempts="${2:-$OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS}"
     local cache_file=""
     local attempt=1
 
     cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
-    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+    if ollama_model_menu_cache_is_fresh "$cache_file" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
         printf '%s\n' "$cache_file"
         return 0
     fi
@@ -97,16 +101,16 @@ prepare_model_menu_cache_with_indicator() {
 Building model selection cache."
         if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")"; then
             attempt=$((attempt + 1))
-            sleep 0.2
+            sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
             continue
         fi
         cache_file="$prepared_cache"
-        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
             printf '%s\n' "$cache_file"
             return 0
         fi
         attempt=$((attempt + 1))
-        sleep 0.2
+        sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
     done
 
     print_error "Failed to prepare a fresh model selection cache after ${max_attempts} attempts."

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -71,8 +71,8 @@ normalize_runtime_override() {
 }
 
 show_model_catalog_loading_indicator() {
-    local message="${1:-Fetching Ollama model catalog...
-Preparing selection dialog.}"
+    local default_message=$'Fetching Ollama model catalog...\nPreparing selection dialog.'
+    local message="${1:-$default_message}"
     if [[ ! -t 0 || ! -t 1 ]]; then
         return 0
     fi
@@ -85,35 +85,32 @@ Preparing selection dialog.}"
 prepare_model_menu_cache_with_indicator() {
     local json_file="$1"
     local max_attempts="${2:-$OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS}"
-    local cache_file=""
+    local cache_path=""
     local attempt=1
 
-    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
-    if ollama_model_menu_cache_is_fresh "$cache_file" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
-        printf '%s\n' "$cache_file"
+    cache_path="$(ollama_model_menu_cache_path "$json_file")" || return 1
+    if ollama_model_menu_cache_is_fresh "$cache_path" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
+        printf '%s\n' "$cache_path"
         return 0
     fi
 
     while (( attempt <= max_attempts )); do
         local prepared_cache=""
 
-        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
-Building model selection cache."
-        if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")"; then
+        show_model_catalog_loading_indicator $'Fetching Ollama model catalog...\nBuilding model selection cache.'
+        if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_path")"; then
             attempt=$((attempt + 1))
             sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
             continue
         fi
-        cache_file="$prepared_cache"
-        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
-            printf '%s\n' "$cache_file"
+        if [[ -n "$prepared_cache" ]] && ollama_model_menu_cache_is_fresh "$prepared_cache" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
+            printf '%s\n' "$prepared_cache"
             return 0
         fi
         attempt=$((attempt + 1))
         sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
     done
 
-    print_error "Failed to prepare a fresh model selection cache after ${max_attempts} attempts."
     return 1
 }
 
@@ -122,33 +119,41 @@ normalize_compare_path() {
     local normalized=""
 
     if [[ -z "$raw_path" ]]; then
-        printf "\n"
+        printf '\n'
         return 0
     fi
 
     if command -v realpath >/dev/null 2>&1; then
         if normalized="$(realpath -m -- "$raw_path" 2>/dev/null)"; then
-            printf "%s\n" "$normalized"
+            printf '%s\n' "$normalized"
             return 0
         fi
     fi
 
     if command -v python3 >/dev/null 2>&1; then
-        if normalized="$(python3 - "$raw_path" <<'PY'
+        if normalized="$(python3 - "$raw_path" <<'PY2'
 import os
 import sys
 
 print(os.path.normpath(os.path.abspath(sys.argv[1])))
-PY
+PY2
         )"; then
-            printf "%s\n" "$normalized"
+            printf '%s\n' "$normalized"
             return 0
         fi
     fi
 
-    normalized="${raw_path%/}"
+    if [[ "$raw_path" == "." || "$raw_path" == "./" ]]; then
+        normalized="$PWD"
+    elif [[ "$raw_path" != /* ]]; then
+        normalized="$PWD/${raw_path#./}"
+    else
+        normalized="$raw_path"
+    fi
+
+    normalized="${normalized%/}"
     [[ -z "$normalized" ]] && normalized="/"
-    printf "%s\n" "$normalized"
+    printf '%s\n' "$normalized"
 }
 
 paths_match_for_message() {

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -91,9 +91,16 @@ prepare_model_menu_cache_with_indicator() {
     fi
 
     while (( attempt <= max_attempts )); do
+        local prepared_cache=""
+
         show_model_catalog_loading_indicator "Fetching Ollama model catalog...
 Building model selection cache."
-        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
+        if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")"; then
+            attempt=$((attempt + 1))
+            sleep 0.2
+            continue
+        fi
+        cache_file="$prepared_cache"
         if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
             printf '%s\n' "$cache_file"
             return 0

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -155,16 +155,20 @@ prepare_model_menu_cache_with_indicator() {
 
         show_model_catalog_loading_indicator "$loading_message"
         if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_path")"; then
+            if (( attempt < max_attempts )); then
+                sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
+            fi
             attempt=$((attempt + 1))
-            sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
             continue
         fi
         if [[ -n "$prepared_cache" ]] && ollama_model_menu_cache_is_fresh "$prepared_cache" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
             printf '%s\n' "$prepared_cache"
             return 0
         fi
+        if (( attempt < max_attempts )); then
+            sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
+        fi
         attempt=$((attempt + 1))
-        sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
     done
 
     return 1

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -27,7 +27,7 @@ print_warning() { printf "WARN: %s\n" "$1"; }
 print_error() { printf "ERROR: %s\n" "$1" >&2; }
 
 OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS="${OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS:-1800}"
-OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS="${OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS:-0.2}"
+OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS="${OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS:-1}"
 OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS="${OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS:-5}"
 
 prompt_install_script_helpers() {
@@ -82,11 +82,25 @@ show_model_catalog_loading_indicator() {
     sleep 0.2
 }
 
+coerce_positive_integer() {
+    local value="${1:-}"
+    local fallback="${2:-1}"
+
+    if [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+        printf '%s\n' "$value"
+        return 0
+    fi
+
+    printf '%s\n' "$fallback"
+}
+
 prepare_model_menu_cache_with_indicator() {
     local json_file="$1"
     local max_attempts="${2:-$OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS}"
     local cache_path=""
     local attempt=1
+
+    max_attempts="$(coerce_positive_integer "$max_attempts" "5")"
 
     cache_path="$(ollama_model_menu_cache_path "$json_file")" || return 1
     if ollama_model_menu_cache_is_fresh "$cache_path" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -65,3 +65,104 @@ normalize_runtime_override() {
     local value="${1:-}"
     printf '%s' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]'
 }
+
+show_model_catalog_loading_indicator() {
+    local message="${1:-Fetching Ollama model catalog...
+Preparing selection dialog.}"
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        return 0
+    fi
+    dialog_init
+    check_if_dialog_installed || return 0
+    dialog --title "ai-runner" --infobox "$message" 8 60
+    sleep 0.2
+}
+
+prepare_model_menu_cache_with_indicator() {
+    local json_file="$1"
+    local max_attempts="${2:-5}"
+    local cache_file=""
+    local attempt=1
+
+    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
+    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+        printf '%s\n' "$cache_file"
+        return 0
+    fi
+
+    while (( attempt <= max_attempts )); do
+        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
+Building model selection cache."
+        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
+        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+            printf '%s\n' "$cache_file"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 0.2
+    done
+
+    print_error "Failed to prepare a fresh model selection cache after ${max_attempts} attempts."
+    return 1
+}
+
+normalize_compare_path() {
+    local raw_path="$1"
+    local normalized=""
+
+    if [[ -z "$raw_path" ]]; then
+        printf "\n"
+        return 0
+    fi
+
+    if command -v realpath >/dev/null 2>&1; then
+        if normalized="$(realpath -m -- "$raw_path" 2>/dev/null)"; then
+            printf "%s\n" "$normalized"
+            return 0
+        fi
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        if normalized="$(python3 - "$raw_path" <<'PY'
+import os
+import sys
+
+print(os.path.normpath(os.path.abspath(sys.argv[1])))
+PY
+        )"; then
+            printf "%s\n" "$normalized"
+            return 0
+        fi
+    fi
+
+    normalized="${raw_path%/}"
+    [[ -z "$normalized" ]] && normalized="/"
+    printf "%s\n" "$normalized"
+}
+
+paths_match_for_message() {
+    local left="$1"
+    local right="$2"
+    [[ "$(normalize_compare_path "$left")" == "$(normalize_compare_path "$right")" ]]
+}
+
+ollama_export_unavailable_message() {
+    local runtime="$1"
+    local requested_dir="$2"
+    local cache_dir="$3"
+
+    if [[ "$runtime" == "docker" ]]; then
+        if paths_match_for_message "$requested_dir" "$cache_dir"; then
+            printf "%s\n" "Model pulled successfully. This Ollama build does not support 'ollama export'; the runtime model store is ${cache_dir}."
+        else
+            printf "%s\n" "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${requested_dir}. The model is available through the Docker runtime store at ${cache_dir}."
+        fi
+        return 0
+    fi
+
+    if paths_match_for_message "$requested_dir" "$cache_dir"; then
+        printf "%s\n" "Model pulled successfully. This Ollama build does not support 'ollama export'; the local runtime model store is ${cache_dir}."
+    else
+        printf "%s\n" "Model pulled successfully. This Ollama build does not support 'ollama export'; no archive was written to ${requested_dir}. The model is available through the local Ollama model store at ${cache_dir}."
+    fi
+}

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -117,12 +117,16 @@ require_model_menu_cache_file() {
     local json_file="$1"
     local cache_file=""
     local status=0
+    local effective_max_attempts=""
+    local effective_ttl_seconds=""
 
     if cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")"; then
         :
     else
         status=$?
-        print_error "Failed to prepare model menu cache."
+        effective_max_attempts="$(coerce_positive_integer "${OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS:-}" "5")"
+        effective_ttl_seconds="$(coerce_positive_integer "${OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS:-}" "1800")"
+        print_error "Failed to prepare model menu cache for JSON file: $json_file (attempts: $effective_max_attempts, TTL seconds: $effective_ttl_seconds)."
         return "$status"
     fi
     if [[ -z "$cache_file" ]]; then

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -94,6 +94,46 @@ coerce_positive_integer() {
     printf '%s\n' "$fallback"
 }
 
+coerce_nonnegative_sleep_delay() {
+    local value="${1:-}"
+    local fallback="${2:-1}"
+
+    if [[ "$value" =~ ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]]; then
+        printf '%s\n' "$value"
+        return 0
+    fi
+
+    printf '%s\n' "$fallback"
+}
+
+sleep_for_cache_retry_delay() {
+    local delay="${1:-$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS}"
+
+    delay="$(coerce_nonnegative_sleep_delay "$delay" "1")"
+    sleep "$delay"
+}
+
+require_model_menu_cache_file() {
+    local json_file="$1"
+    local cache_file=""
+    local status=0
+
+    if cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")"; then
+        :
+    else
+        status=$?
+        print_error "Failed to prepare model menu cache."
+        return "$status"
+    fi
+    if [[ -z "$cache_file" ]]; then
+        print_error "Model menu cache path is empty."
+        return 1
+    fi
+
+    export OLLAMA_MODEL_MENU_CACHE_FILE="$cache_file"
+    printf '%s\n' "$cache_file"
+}
+
 prepare_model_menu_cache_with_indicator() {
     local json_file="$1"
     local max_attempts="${2:-$OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS}"
@@ -111,10 +151,12 @@ prepare_model_menu_cache_with_indicator() {
     while (( attempt <= max_attempts )); do
         local prepared_cache=""
 
-        show_model_catalog_loading_indicator $'Fetching Ollama model catalog...\nBuilding model selection cache.'
+        local loading_message=$'Fetching Ollama model catalog...\nBuilding model selection cache.'
+
+        show_model_catalog_loading_indicator "$loading_message"
         if ! prepared_cache="$(ollama_prepare_model_menu_cache "$json_file" "$cache_path")"; then
             attempt=$((attempt + 1))
-            sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
+            sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
             continue
         fi
         if [[ -n "$prepared_cache" ]] && ollama_model_menu_cache_is_fresh "$prepared_cache" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
@@ -122,7 +164,7 @@ prepare_model_menu_cache_with_indicator() {
             return 0
         fi
         attempt=$((attempt + 1))
-        sleep "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
+        sleep_for_cache_retry_delay "$OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS"
     done
 
     return 1

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -137,20 +137,21 @@ require_model_menu_cache_file() {
 prepare_model_menu_cache_with_indicator() {
     local json_file="$1"
     local max_attempts="${2:-$OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS}"
+    local ttl_seconds="$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"
     local cache_path=""
     local attempt=1
 
     max_attempts="$(coerce_positive_integer "$max_attempts" "5")"
+    ttl_seconds="$(coerce_positive_integer "$ttl_seconds" "1800")"
 
     cache_path="$(ollama_model_menu_cache_path "$json_file")" || return 1
-    if ollama_model_menu_cache_is_fresh "$cache_path" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
+    if ollama_model_menu_cache_is_fresh "$cache_path" "$ttl_seconds"; then
         printf '%s\n' "$cache_path"
         return 0
     fi
 
     while (( attempt <= max_attempts )); do
         local prepared_cache=""
-
         local loading_message=$'Fetching Ollama model catalog...\nBuilding model selection cache.'
 
         show_model_catalog_loading_indicator "$loading_message"
@@ -161,7 +162,7 @@ prepare_model_menu_cache_with_indicator() {
             attempt=$((attempt + 1))
             continue
         fi
-        if [[ -n "$prepared_cache" ]] && ollama_model_menu_cache_is_fresh "$prepared_cache" "$OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS"; then
+        if [[ -n "$prepared_cache" ]] && ollama_model_menu_cache_is_fresh "$prepared_cache" "$ttl_seconds"; then
             printf '%s\n' "$prepared_cache"
             return 0
         fi
@@ -177,6 +178,14 @@ prepare_model_menu_cache_with_indicator() {
 normalize_compare_path() {
     local raw_path="$1"
     local normalized=""
+    local abs_path=""
+    local parent_dir=""
+    local base_name=""
+    local dir_norm=""
+    local joined=""
+    local -a parts=()
+    local -a resolved=("")
+    local part=""
 
     if [[ -z "$raw_path" ]]; then
         printf '\n'
@@ -203,19 +212,51 @@ PY2
         fi
     fi
 
-    if [[ "$raw_path" == "." || "$raw_path" == "./" ]]; then
-        normalized="$PWD"
-    elif [[ "$raw_path" != /* ]]; then
-        normalized="$PWD/${raw_path#./}"
-    else
-        normalized="$raw_path"
+    if [[ -e "$raw_path" ]]; then
+        if [[ -d "$raw_path" ]]; then
+            if normalized="$(cd "$raw_path" 2>/dev/null && pwd -P)"; then
+                printf '%s\n' "$normalized"
+                return 0
+            fi
+        else
+            parent_dir="$(dirname -- "$raw_path")"
+            base_name="$(basename -- "$raw_path")"
+            if dir_norm="$(cd "$parent_dir" 2>/dev/null && pwd -P)"; then
+                printf '%s\n' "${dir_norm%/}/$base_name"
+                return 0
+            fi
+        fi
     fi
 
-    normalized="${normalized%/}"
-    [[ -z "$normalized" ]] && normalized="/"
+    if [[ "$raw_path" == /* ]]; then
+        abs_path="$raw_path"
+    else
+        abs_path="$PWD/${raw_path#./}"
+    fi
+
+    IFS='/' read -r -a parts <<< "$abs_path"
+    for part in "${parts[@]}"; do
+        if [[ -z "$part" || "$part" == "." ]]; then
+            continue
+        fi
+        if [[ "$part" == ".." ]]; then
+            if (( ${#resolved[@]} > 1 )); then
+                unset 'resolved[${#resolved[@]}-1]'
+            fi
+            continue
+        fi
+        resolved+=("$part")
+    done
+
+    if (( ${#resolved[@]} == 1 )); then
+        normalized="/"
+    else
+        joined="${resolved[*]:1}"
+        normalized="/${joined// /\/}"
+    fi
+
     printf '%s\n' "$normalized"
 }
-
 paths_match_for_message() {
     local left="$1"
     local right="$2"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -181,7 +181,16 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-export OLLAMA_MODEL_MENU_CACHE_FILE="$(prepare_model_menu_cache_with_indicator "$json_file")"
+cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")" || {
+    status=$?
+    print_error "Failed to prepare model menu cache."
+    exit "$status"
+}
+if [[ -z "$cache_file" ]]; then
+    print_error "Model menu cache path is empty."
+    exit 1
+fi
+export OLLAMA_MODEL_MENU_CACHE_FILE="$cache_file"
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"
 if [[ -n "$model" ]]; then
@@ -190,7 +199,15 @@ fi
 
 current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
 while true; do
-    selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"
+    if ! selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+        status=$?
+        if [[ $status -eq 2 ]]; then
+            print_info "Model selection cancelled."
+            exit 0
+        fi
+        print_error "Failed to select model."
+        exit "$status"
+    fi
     if selected_size="$(ollama_dialog_select_size "$json_file" "$selected_model" "$current_size")"; then
         break
     fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -152,9 +152,7 @@ if $run_install; then
 fi
 
 if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
-    if choose_start_action; then
-        show_model_catalog_loading_indicator "Preparing selection dialog..."
-    else
+    if ! choose_start_action; then
         status=$?
         if [[ $status -eq 2 ]]; then
             print_info "Run cancelled."
@@ -180,6 +178,9 @@ json_file="$(ollama_models_json_path "$MODEL_REPO_DIR")"
 if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
+fi
+if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
+    show_model_catalog_loading_indicator "Preparing selection dialog..."
 fi
 require_model_menu_cache_file "$json_file" >/dev/null || exit "$?"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -120,42 +120,6 @@ copy_to_clipboard_safe() {
     fi
 }
 
-show_model_catalog_loading_indicator() {
-    local message="${1:-Fetching Ollama model catalog...
-Preparing selection dialog.}"
-    if [[ ! -t 0 || ! -t 1 ]]; then
-        return 0
-    fi
-    dialog_init
-    check_if_dialog_installed || return 0
-    dialog --title "ai-runner" --infobox "$message" 8 60
-    sleep 0.2
-}
-
-prepare_model_menu_cache_with_indicator() {
-    local json_file="$1"
-    local cache_file=""
-
-    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
-    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
-        printf '%s
-' "$cache_file"
-        return 0
-    fi
-
-    while true; do
-        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
-Building model selection cache."
-        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
-        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
-            printf '%s
-' "$cache_file"
-            return 0
-        fi
-        sleep 0.2
-    done
-}
-
 run_install=false
 model=""
 prompt=""

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -181,7 +181,9 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-if ! cache_file="$(require_model_menu_cache_file "$json_file")"; then
+if require_model_menu_cache_file "$json_file" >/dev/null; then
+    :
+else
     status=$?
     exit "$status"
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -120,6 +120,42 @@ copy_to_clipboard_safe() {
     fi
 }
 
+show_model_catalog_loading_indicator() {
+    local message="${1:-Fetching Ollama model catalog...
+Preparing selection dialog.}"
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        return 0
+    fi
+    dialog_init
+    check_if_dialog_installed || return 0
+    dialog --title "ai-runner" --infobox "$message" 8 60
+    sleep 0.2
+}
+
+prepare_model_menu_cache_with_indicator() {
+    local json_file="$1"
+    local cache_file=""
+
+    cache_file="$(ollama_model_menu_cache_path "$json_file")" || return 1
+    if ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+        printf '%s
+' "$cache_file"
+        return 0
+    fi
+
+    while true; do
+        show_model_catalog_loading_indicator "Fetching Ollama model catalog...
+Building model selection cache."
+        cache_file="$(ollama_prepare_model_menu_cache "$json_file" "$cache_file")" || return 1
+        if [[ -n "$cache_file" ]] && ollama_model_menu_cache_is_fresh "$cache_file" 1800; then
+            printf '%s
+' "$cache_file"
+            return 0
+        fi
+        sleep 0.2
+    done
+}
+
 run_install=false
 model=""
 prompt=""
@@ -153,7 +189,7 @@ fi
 
 if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
     if choose_start_action; then
-        :
+        show_model_catalog_loading_indicator
     else
         status=$?
         if [[ $status -eq 2 ]]; then
@@ -181,15 +217,27 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
+export OLLAMA_MODEL_MENU_CACHE_FILE="$(prepare_model_menu_cache_with_indicator "$json_file")"
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"
 if [[ -n "$model" ]]; then
     current_model="$model"
 fi
 
-selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"
 current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
-selected_size="$(ollama_dialog_select_size "$json_file" "$selected_model" "$current_size")"
+while true; do
+    selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"
+    if selected_size="$(ollama_dialog_select_size "$json_file" "$selected_model" "$current_size")"; then
+        break
+    fi
+    status=$?
+    if [[ $status -eq 2 ]]; then
+        current_model="$selected_model"
+        continue
+    fi
+    print_error "Failed to select model size."
+    exit "$status"
+done
 
 ollama_update_env "$ENV_FILE" model "$selected_model"
 ollama_update_env "$ENV_FILE" size "$selected_size"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -179,10 +179,6 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
-    show_model_catalog_loading_indicator "Preparing selection dialog..."
-fi
-require_model_menu_cache_file "$json_file" >/dev/null || exit "$?"
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"
 if [[ -n "$model" ]]; then
@@ -190,27 +186,33 @@ if [[ -n "$model" ]]; then
 fi
 
 current_size="$(resolve_env_value "size" "latest" "$ENV_FILE")"
-while true; do
-    if ! selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+selected_model="$current_model"
+selected_size="$current_size"
+if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
+    show_model_catalog_loading_indicator "Preparing selection dialog..."
+    require_model_menu_cache_file "$json_file" >/dev/null || exit "$?"
+    while true; do
+        if ! selected_model="$(ollama_dialog_select_model "$json_file" "$current_model")"; then
+            status=$?
+            if [[ $status -eq 2 ]]; then
+                print_info "Model selection cancelled."
+                exit 0
+            fi
+            print_error "Failed to select model."
+            exit "$status"
+        fi
+        if selected_size="$(ollama_dialog_select_size "$json_file" "$selected_model" "$current_size")"; then
+            break
+        fi
         status=$?
         if [[ $status -eq 2 ]]; then
-            print_info "Model selection cancelled."
-            exit 0
+            current_model="$selected_model"
+            continue
         fi
-        print_error "Failed to select model."
+        print_error "Failed to select model size."
         exit "$status"
-    fi
-    if selected_size="$(ollama_dialog_select_size "$json_file" "$selected_model" "$current_size")"; then
-        break
-    fi
-    status=$?
-    if [[ $status -eq 2 ]]; then
-        current_model="$selected_model"
-        continue
-    fi
-    print_error "Failed to select model size."
-    exit "$status"
-done
+    done
+fi
 
 ollama_update_env "$ENV_FILE" model "$selected_model"
 ollama_update_env "$ENV_FILE" size "$selected_size"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -181,12 +181,7 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-if require_model_menu_cache_file "$json_file" >/dev/null; then
-    :
-else
-    status=$?
-    exit "$status"
-fi
+require_model_menu_cache_file "$json_file" >/dev/null || exit "$?"
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"
 if [[ -n "$model" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -153,7 +153,7 @@ fi
 
 if [[ -t 0 && -t 1 && -z "$model" && -z "$prompt" ]] && ! $run_install; then
     if choose_start_action; then
-        show_model_catalog_loading_indicator
+        show_model_catalog_loading_indicator "Preparing selection dialog..."
     else
         status=$?
         if [[ $status -eq 2 ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -181,10 +181,9 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-if cache_file="$(require_model_menu_cache_file "$json_file")"; then
-    :
-else
-    exit $?
+if ! cache_file="$(require_model_menu_cache_file "$json_file")"; then
+    status=$?
+    exit "$status"
 fi
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -181,16 +181,11 @@ if [[ ! -f "$json_file" ]]; then
     print_info "Model index not found. Preparing..."
     json_file="$(ollama_prepare_models_index "$MODEL_REPO_DIR")"
 fi
-cache_file="$(prepare_model_menu_cache_with_indicator "$json_file")" || {
-    status=$?
-    print_error "Failed to prepare model menu cache."
-    exit "$status"
-}
-if [[ -z "$cache_file" ]]; then
-    print_error "Model menu cache path is empty."
-    exit 1
+if cache_file="$(require_model_menu_cache_file "$json_file")"; then
+    :
+else
+    exit $?
 fi
-export OLLAMA_MODEL_MENU_CACHE_FILE="$cache_file"
 
 current_model="$(resolve_env_value "model" "$DEFAULT_MODEL" "$ENV_FILE")"
 if [[ -n "$model" ]]; then

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -71,6 +71,30 @@ ollama_prepare_model_menu_cache() { return 1; }
 show_model_catalog_loading_indicator() { :; }
 
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=bogus OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
-    printf 'Expected invalid max attempts to fall back and return failure after retries.\n' >&2
+    printf 'Expected invalid max attempts to fall back and return failure after retries.
+' >&2
     exit 1
 fi
+
+if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=bogus prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
+    printf 'Expected invalid retry delay to fall back and still return failure after retries.
+' >&2
+    exit 1
+fi
+
+if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=bogus require_model_menu_cache_file "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
+    printf 'Expected require_model_menu_cache_file to fail when cache prep fails.
+' >&2
+    exit 1
+fi
+
+ollama_prepare_model_menu_cache() { printf '%s
+' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
+ollama_model_menu_cache_is_fresh() { [[ "$1" == "$PROJECT_ROOT/.tmp-menu-cache.json" ]]; }
+cache_output_file="$PROJECT_ROOT/.tmp-cache-output.txt"
+rm -f "$cache_output_file"
+require_model_menu_cache_file "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json" >"$cache_output_file"
+cache_path="$(cat "$cache_output_file")"
+rm -f "$cache_output_file"
+assert_contains "$cache_path" "$PROJECT_ROOT/.tmp-menu-cache.json" "require_model_menu_cache_file returns cache path"
+assert_contains "$OLLAMA_MODEL_MENU_CACHE_FILE" "$PROJECT_ROOT/.tmp-menu-cache.json" "require_model_menu_cache_file exports cache path"

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -39,6 +39,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/include.sh"
 
+cd "$PROJECT_ROOT"
+
 assert_contains() {
     local haystack=$1
     local needle=$2
@@ -62,3 +64,13 @@ assert_contains "$docker_diff" "Docker runtime store at ${models_dir}." "docker_
 assert_contains "$local_same" "the local runtime model store is ${models_dir}." "local_same: local runtime model store path"
 assert_contains "$local_diff" "no archive was written to ./models/custom." "local_diff: no archive written message"
 assert_contains "$local_diff" "local Ollama model store at ${models_dir}." "local_diff: local Ollama model store path"
+
+ollama_model_menu_cache_path() { printf '%s\n' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
+ollama_model_menu_cache_is_fresh() { return 1; }
+ollama_prepare_model_menu_cache() { return 1; }
+show_model_catalog_loading_indicator() { :; }
+
+if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=bogus OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
+    printf 'Expected invalid max attempts to fall back and return failure after retries.\n' >&2
+    exit 1
+fi

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -80,6 +80,20 @@ if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SE
     exit 1
 fi
 
+ttl_seen=""
+ollama_model_menu_cache_is_fresh() {
+    ttl_seen="$2"
+    return 1
+}
+if OLLAMA_MODEL_MENU_CACHE_TTL_SECONDS=bogus OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
+    printf 'Expected invalid TTL to fall back and still return failure after retries.\n' >&2
+    exit 1
+fi
+if [[ "$ttl_seen" != "1800" ]]; then
+    printf 'Expected invalid TTL to be coerced to 1800, got: %s\n' "$ttl_seen" >&2
+    exit 1
+fi
+
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=bogus require_model_menu_cache_file "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
     printf 'Expected require_model_menu_cache_file to fail when cache prep fails.\n' >&2
     exit 1
@@ -103,3 +117,8 @@ cache_path="$(cat "$cache_output_file")"
 rm -f "$cache_output_file"
 assert_contains "$cache_path" "$PROJECT_ROOT/.tmp-menu-cache.json" "require_model_menu_cache_file returns cache path"
 assert_contains "$OLLAMA_MODEL_MENU_CACHE_FILE" "$PROJECT_ROOT/.tmp-menu-cache.json" "require_model_menu_cache_file exports cache path"
+
+realpath() { return 1; }
+python3() { return 1; }
+normalized_existing="$(normalize_compare_path "./models/../models")"
+assert_contains "$normalized_existing" "$models_dir" "normalize_compare_path collapses relative dot-dot path"

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -71,26 +71,31 @@ ollama_prepare_model_menu_cache() { return 1; }
 show_model_catalog_loading_indicator() { :; }
 
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=bogus OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
-    printf 'Expected invalid max attempts to fall back and return failure after retries.
-' >&2
+    printf 'Expected invalid max attempts to fall back and return failure after retries.\n' >&2
     exit 1
 fi
 
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=bogus prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
-    printf 'Expected invalid retry delay to fall back and still return failure after retries.
-' >&2
+    printf 'Expected invalid retry delay to fall back and still return failure after retries.\n' >&2
     exit 1
 fi
 
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=bogus require_model_menu_cache_file "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
-    printf 'Expected require_model_menu_cache_file to fail when cache prep fails.
-' >&2
+    printf 'Expected require_model_menu_cache_file to fail when cache prep fails.\n' >&2
     exit 1
 fi
 
-ollama_prepare_model_menu_cache() { printf '%s
-' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
+sleep_calls=0
+sleep_for_cache_retry_delay() { sleep_calls=$((sleep_calls + 1)); }
+OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json" >/dev/null 2>&1 || true
+if [[ $sleep_calls -ne 0 ]]; then
+    printf 'Expected no retry sleep after the last allowed cache-prep attempt.\n' >&2
+    exit 1
+fi
+
+ollama_prepare_model_menu_cache() { printf '%s\n' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
 ollama_model_menu_cache_is_fresh() { [[ "$1" == "$PROJECT_ROOT/.tmp-menu-cache.json" ]]; }
+sleep_for_cache_retry_delay() { :; }
 cache_output_file="$PROJECT_ROOT/.tmp-cache-output.txt"
 rm -f "$cache_output_file"
 require_model_menu_cache_file "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json" >"$cache_output_file"

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -39,7 +39,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/include.sh"
 
-models_dir="$(pwd)/models"
+models_dir="${PROJECT_ROOT}/models"
 docker_same="$(ollama_export_unavailable_message docker "./models/" "$models_dir")"
 docker_diff="$(ollama_export_unavailable_message docker "./models/custom" "$models_dir")"
 local_same="$(ollama_export_unavailable_message local "./models/" "$models_dir")"

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -34,6 +34,14 @@ while getopts ":h" opt; do
     esac
 done
 
+shift "$((OPTIND - 1))"
+
+if [ "$#" -ne 0 ]; then
+    printf 'Unexpected positional arguments: %s\n\n' "$*" >&2
+    help >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=/dev/null

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -39,15 +39,26 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=/dev/null
 source "$PROJECT_ROOT/scripts/include.sh"
 
+assert_contains() {
+    local haystack=$1
+    local needle=$2
+    local label=$3
+
+    if [[ "$haystack" != *"$needle"* ]]; then
+        printf 'Assertion failed: %s\nExpected to find: %s\nIn: %s\n' "$label" "$needle" "$haystack" >&2
+        exit 1
+    fi
+}
+
 models_dir="${PROJECT_ROOT}/models"
 docker_same="$(ollama_export_unavailable_message docker "./models/" "$models_dir")"
 docker_diff="$(ollama_export_unavailable_message docker "./models/custom" "$models_dir")"
 local_same="$(ollama_export_unavailable_message local "./models/" "$models_dir")"
 local_diff="$(ollama_export_unavailable_message local "./models/custom" "$models_dir")"
 
-[[ "$docker_same" == *"the runtime model store is ${models_dir}."* ]]
-[[ "$docker_diff" == *"no archive was written to ./models/custom."* ]]
-[[ "$docker_diff" == *"Docker runtime store at ${models_dir}."* ]]
-[[ "$local_same" == *"the local runtime model store is ${models_dir}."* ]]
-[[ "$local_diff" == *"no archive was written to ./models/custom."* ]]
-[[ "$local_diff" == *"local Ollama model store at ${models_dir}."* ]]
+assert_contains "$docker_same" "the runtime model store is ${models_dir}." "docker_same: runtime model store path"
+assert_contains "$docker_diff" "no archive was written to ./models/custom." "docker_diff: no archive written message"
+assert_contains "$docker_diff" "Docker runtime store at ${models_dir}." "docker_diff: Docker runtime store path"
+assert_contains "$local_same" "the local runtime model store is ${models_dir}." "local_same: local runtime model store path"
+assert_contains "$local_diff" "no archive was written to ./models/custom." "local_diff: no archive written message"
+assert_contains "$local_diff" "local Ollama model store at ${models_dir}." "local_diff: local Ollama model store path"

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SCRIPT: test-get-fallback-messages.sh
+# DESCRIPTION: Verify fallback success messages when Ollama export is unavailable.
+# USAGE: bash tests/test-get-fallback-messages.sh [-h]
+# PARAMETERS:
+# -h                : show help
+# EXAMPLE: bash tests/test-get-fallback-messages.sh
+# ----------------------------------------------------
+set -euo pipefail
+
+help() {
+    cat <<'EOF'
+Verify fallback success messaging for ./get when Ollama export is unavailable.
+
+Usage:
+  bash tests/test-get-fallback-messages.sh [-h]
+
+Options:
+  -h    Show help
+EOF
+}
+
+while getopts ":h" opt; do
+    case "${opt}" in
+        h)
+            help
+            exit 0
+            ;;
+        \?)
+            printf 'Invalid option: -%s\n\n' "$OPTARG" >&2
+            help >&2
+            exit 1
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/scripts/include.sh"
+
+models_dir="$(pwd)/models"
+docker_same="$(ollama_export_unavailable_message docker "./models/" "$models_dir")"
+docker_diff="$(ollama_export_unavailable_message docker "./models/custom" "$models_dir")"
+local_same="$(ollama_export_unavailable_message local "./models/" "$models_dir")"
+local_diff="$(ollama_export_unavailable_message local "./models/custom" "$models_dir")"
+
+[[ "$docker_same" == *"the runtime model store is ${models_dir}."* ]]
+[[ "$docker_diff" == *"no archive was written to ./models/custom."* ]]
+[[ "$docker_diff" == *"Docker runtime store at ${models_dir}."* ]]
+[[ "$local_same" == *"the local runtime model store is ${models_dir}."* ]]
+[[ "$local_diff" == *"no archive was written to ./models/custom."* ]]
+[[ "$local_diff" == *"local Ollama model store at ${models_dir}."* ]]

--- a/tests/test-get-fallback-messages.sh
+++ b/tests/test-get-fallback-messages.sh
@@ -66,8 +66,11 @@ assert_contains "$local_diff" "no archive was written to ./models/custom." "loca
 assert_contains "$local_diff" "local Ollama model store at ${models_dir}." "local_diff: local Ollama model store path"
 
 ollama_model_menu_cache_path() { printf '%s\n' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
+# shellcheck disable=SC2317
 ollama_model_menu_cache_is_fresh() { return 1; }
+# shellcheck disable=SC2317
 ollama_prepare_model_menu_cache() { return 1; }
+# shellcheck disable=SC2317
 show_model_catalog_loading_indicator() { :; }
 
 if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=bogus OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json"; then
@@ -81,6 +84,7 @@ if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SE
 fi
 
 ttl_seen=""
+# shellcheck disable=SC2317
 ollama_model_menu_cache_is_fresh() {
     ttl_seen="$2"
     return 1
@@ -100,6 +104,7 @@ if OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SE
 fi
 
 sleep_calls=0
+# shellcheck disable=SC2317
 sleep_for_cache_retry_delay() { sleep_calls=$((sleep_calls + 1)); }
 OLLAMA_MODEL_MENU_CACHE_MAX_ATTEMPTS=1 OLLAMA_MODEL_MENU_CACHE_RETRY_DELAY_SECONDS=0 prepare_model_menu_cache_with_indicator "$PROJECT_ROOT/ollama-get-models/code/ollama_models.json" >/dev/null 2>&1 || true
 if [[ $sleep_calls -ne 0 ]]; then
@@ -107,8 +112,11 @@ if [[ $sleep_calls -ne 0 ]]; then
     exit 1
 fi
 
+# shellcheck disable=SC2317
 ollama_prepare_model_menu_cache() { printf '%s\n' "$PROJECT_ROOT/.tmp-menu-cache.json"; }
+# shellcheck disable=SC2317
 ollama_model_menu_cache_is_fresh() { [[ "$1" == "$PROJECT_ROOT/.tmp-menu-cache.json" ]]; }
+# shellcheck disable=SC2317
 sleep_for_cache_retry_delay() { :; }
 cache_output_file="$PROJECT_ROOT/.tmp-cache-output.txt"
 rm -f "$cache_output_file"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -20,6 +20,7 @@ Options:
 
 Current coverage:
   - tests/test-chat-completions.sh
+  - tests/test-get-fallback-messages.sh
 EOF
 }
 
@@ -41,4 +42,5 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 printf 'Running shell smoke tests...\n'
 bash "$SCRIPT_DIR/test-chat-completions.sh"
+bash "$SCRIPT_DIR/test-get-fallback-messages.sh"
 printf 'Shell smoke tests completed.\n'

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SCRIPT: test.sh
+# DESCRIPTION: Run the shell-based ai-runner smoke test suite.
+# USAGE: bash tests/test.sh [-h]
+# PARAMETERS:
+# -h                : show help
+# EXAMPLE: bash tests/test.sh
+# ----------------------------------------------------
+set -euo pipefail
+
+help() {
+    cat <<'EOF'
+Run the shell-based ai-runner smoke tests.
+
+Usage:
+  bash tests/test.sh [-h]
+
+Options:
+  -h    Show help
+
+Current coverage:
+  - tests/test-chat-completions.sh
+EOF
+}
+
+while getopts ":h" opt; do
+    case "${opt}" in
+        h)
+            help
+            exit 0
+            ;;
+        \?)
+            printf 'Invalid option: -%s\n\n' "$OPTARG" >&2
+            help >&2
+            exit 1
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+printf 'Running shell smoke tests...\n'
+bash "$SCRIPT_DIR/test-chat-completions.sh"
+printf 'Shell smoke tests completed.\n'

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -39,6 +39,9 @@ while getopts ":h" opt; do
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
 
 printf 'Running shell smoke tests...\n'
 bash "$SCRIPT_DIR/test-chat-completions.sh"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -38,6 +38,14 @@ while getopts ":h" opt; do
     esac
 done
 
+shift "$((OPTIND - 1))"
+
+if [ "$#" -ne 0 ]; then
+    printf 'Unexpected positional arguments: %s\n\n' "$*" >&2
+    help >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 


### PR DESCRIPTION
## Summary
- Fix the broken `./get` archive-safety/path-message implementation on `release/0.1.2` by restoring the truncated validation function and removing duplicate variable initialization.
- Extract shared model-catalog loading/cache helpers into `scripts/include.sh`, add bounded cache refresh retries, and keep `./run`/`./get` behavior aligned without editing the vendored `script-helpers` submodule.
- Add shell regression coverage for `./get` fallback success messaging when the requested output directory matches or differs from the Ollama runtime model store.

## Testing
- `bash -n scripts/get.sh`
- `bash -n scripts/run.sh`
- `bash tests/test-get-fallback-messages.sh`
- `STRICT=1 ./scripts/lint.sh`