### PR TITLE
[codex] Mark changelog release versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+models/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # CHANGELOG
 
 ## Unreleased
+- Tooling: ignore local downloaded model artifacts under `models/`.
+- Tooling: update `scripts/script-helpers` to include stabilized Ollama dialog selector behavior for TTY sessions.
+
+## [0.1.2] - 2026-03-23
 - Fix: restore fully TUI-based model selection in `./run` and `./get` with no free-form model-name entry.
 - Fix: default interactive model browsing to official un-namespaced Ollama library models, sorted alphabetically, to avoid community duplicates in the main selector.
 - Fix: keep interactive selection loops in `./run` and `./get` so cancelling the size dialog returns to model selection instead of silently reusing a prior size.
 - Fix: show a loading indicator before opening the model selector and reuse a parsed model-menu cache for up to 30 minutes to speed up reopen flows.
 - Fix: route Ollama pull progress through a dialog gauge and prevent helper status output from corrupting `.env` values.
 
+## [0.1.1] - 2026-03-16
 - Feature: add an `About` dialog to `./run` with project links plus GitHub and LinkedIn profile links.
 - Fix: keep `./run -i` bootstrap flow install-first so fresh machines do not require `dialog` before dependency setup.
 - Fix: clarify `./get` fallback success messages so the requested output directory and the actual Ollama runtime model-store path are reported separately when export is unavailable.
@@ -24,6 +29,11 @@
 - Config: introduce `ollama_scheme`, `ollama_host`, and `ollama_port`; auto-generate/sync `ollama_url` from these fields in scripts.
 - Config: add shared model-store controls (`ollama_shared_model_store`, `ollama_local_models_dir`) to reuse pulled models across local and Docker runtimes.
 - Docs: update README and command docs for runtime selection, model sharing, and new env structure.
+
+## [0.1.0] - 2026-02-04
+- Feature: release the improved TUI setup and run flow from PR #10.
+- Tooling: update `scripts/setup-deps.sh`, `example.sh`, CI helper wiring, and the `scripts/script-helpers` submodule.
+- Fix: gate dependency setup and pin CI helper usage for the release workflow.
 
 ## 2025-12-30
 - Refactor: move root scripts into `scripts/` and keep entrypoint symlinks (`run`, `get`, `prompt`) at repo root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # CHANGELOG
 
-## Unreleased
+## [0.1.4] - Unreleased
 - Tooling: ignore local downloaded model artifacts under `models/`.
 - Tooling: update `scripts/script-helpers` to include stabilized Ollama dialog selector behavior for TTY sessions.
+
+## [0.1.3] - 2026-04-28
+- Feature: add Ollama registry bundle download support in `./get`, including manifest/blob staging and digest verification.
+- Fix: restore interactive model selection in `./run` and `./get` after the selector flow regressed.
+- Fix: make `./get` fallback handling explicit when export is unavailable, including clearer success and failure messaging.
+- Fix: harden non-interactive prompt/model guards so scripted runs fail clearly instead of opening dialogs.
+- Fix: make registry bundle staging, finalization, and temporary-file handling safer across failure paths.
+- CI: tighten release tag detection and switch to the shared ci-helpers auto-tag workflow.
+- Tooling: add portable registry bundle tests and shell probes for the download flow.
 
 ## [0.1.2] - 2026-03-23
 - Fix: restore fully TUI-based model selection in `./run` and `./get` with no free-form model-name entry.


### PR DESCRIPTION
## Summary

- Mark tagged changelog releases with both version tags and release dates for `0.1.3`, `0.1.2`, `0.1.1`, and `0.1.0`.
- Keep the untagged feature release section as a date-only entry.
- Document the pending `0.1.4` release changes under `[0.1.4] - Unreleased`: ignoring local `models/` artifacts and updating `scripts/script-helpers` for stabilized Ollama dialog selector behavior.

## Validation

- `bash tests/test.sh`
- `PATH=/tmp/shellcheck-local/usr/bin:$PATH STRICT=1 bash ./scripts/lint.sh`
- `bash -n scripts/get.sh`
- `bash -n scripts/run.sh`