### PR TITLE
ci: pin ci-helpers to production instead of 0.6.1

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shellcheck:
-    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@0.6.1
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       lint_command: |
         sudo apt clean


### PR DESCRIPTION
## What

The `shellcheck.yml` workflow was pinned to `nikolareljin/ci-helpers@0.6.1`. Every other workflow in this repo already tracks `@production`.

## Why

A stale pin means this repo silently misses fixes the shared workflows have already shipped, and the gap widens with every release. It is also the only remaining pin violation here.

## Scope

One line. No behaviour change expected beyond picking up the current shared workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)