### PR TITLE
ci: move the shellcheck pin to @production

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,15 @@ on:
 
 jobs:
   shellcheck:
-    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@0.6.1
+    # @production, like auto-tag-release.yml in this repository already
+    # uses. The pin sat at 0.6.1 while the shared workflows moved on, so this
+    # job has been running a version from long before the timeout bounds, the
+    # Node 24 opt-in and the concurrency fixes -- none of which it was opting
+    # out of deliberately.
+    #
+    # Safe to move: lint_command is still accepted, and every other command
+    # input defaults to empty, so nothing new starts running.
+    uses: nikolareljin/ci-helpers/.github/workflows/ci.yml@production
     with:
       lint_command: |
         sudo apt clean


### PR DESCRIPTION
`shellcheck.yml` pinned `ci-helpers` at **0.6.1** while `auto-tag-release.yml` in the same repository already tracked `@production`. So half this repository's CI was frozen at a version predating the job timeout bounds, the Node 24 opt-in, and the concurrency fixes — none of which it was opting out of deliberately. The pin was simply never moved.

## Checked before moving

`ci.yml@production` still accepts `lint_command`, and every other command input defaults to empty:

```
lint_command:    default=''
test_command:    default=''
build_command:   default=''
docker_command:  default=''
e2e_command:     default=''
extra_command:   default=''
```

So nothing new starts running as a side effect of the bump — the job does exactly what it did, on a maintained version.