### PR TITLE
ci: call the least-privilege auto-tag.yml

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   tag:
-    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    uses: nikolareljin/ci-helpers/.github/workflows/auto-tag.yml@production


### PR DESCRIPTION
## What

Points this repo at ci-helpers' tag-only `auto-tag.yml` instead of `auto-tag-release.yml`.

## Why

`auto-tag-release.yml` declares a `workflow_dispatch` job, so its workflow-level `permissions:` block includes `actions: write`. GitHub validates a reusable workflow's declared permissions **at startup, regardless of any job `if:` gate** — so every caller must grant `actions: write`, even one that never dispatches. Without it the run fails `startup_failure` before a step executes.

This repo passes no `release_workflow` input, so it never dispatches and never needed the permission. It has been paying the requirement for a feature it does not use.

ci-helpers split out the least-privilege `auto-tag.yml` for exactly this case ([#121](https://github.com/nikolareljin/ci-helpers/pull/121), 0.18.0, 2026-07-28) and pointed the tag-only docs at it. This finishes that migration here.

## Why it has not bitten yet

The requirement landed after this repo's last merge to its default branch. The break is latent — it fires on the next merge, which is a bad moment to discover it.

Found while fixing the same failure in another repo, where it did fire. Nine other repos in the fleet are in the same state and are getting the same change.

## Risk

One line. Inputs and outputs of the two reusable workflows are identical for tag-only callers; `auto-tag-release.yml` delegates its tagging to `auto-tag.yml` already. Nothing is lost because nothing dispatched.