### PR TITLE
release: 0.1.5

### DIFF
--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -1,0 +1,46 @@
+name: Submodules
+
+# A submodule pin is only as good as the remote's ability to serve it. Tags
+# 0.1.3 and 0.1.4 shipped a scripts/script-helpers pin that no longer existed
+# upstream, so `git clone --recurse-submodules` failed for every consumer:
+#
+#   fatal: remote error: upload-pack: not our ref c11b42a...
+#
+# Nothing in CI checked out submodules, so it went unnoticed from April to
+# August. This job does the one thing that reproduces the consumer's failure.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  pins:
+    name: Submodule pins are fetchable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check out every submodule at its recorded commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f .gitmodules ]; then
+            echo "No .gitmodules, nothing to verify."
+            exit 0
+          fi
+          git submodule status
+          if ! git submodule update --init --recursive; then
+            echo "::error::A submodule pin cannot be fetched from its remote."
+            echo "The recorded commit is gone upstream, usually because it was"
+            echo "never pushed or lived on a branch that was deleted. Point the"
+            echo "submodule at a commit that exists (a published tag is safest)"
+            echo "and commit the new gitlink."
+            exit 1
+          fi
+          echo "All submodule pins resolved."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## [0.1.4] - Unreleased
+## [0.1.5] - 2026-08-21
+- Fix: point `scripts/script-helpers` at the published `0.22.0` tag. Tags `0.1.3` and `0.1.4` recorded commit `c11b42a`, which does not exist in `script-helpers` and is unknown to GitHub, so `git clone --recurse-submodules` failed for anyone installing from a release: `upload-pack: not our ref c11b42a`. The commit was never merged into any surviving ref, so there is nothing to restore; the pin now tracks a published tag rather than whatever the working tree happened to hold.
+- CI: check out submodules on every pull request. Nothing in CI touched them, which is why a pin that no consumer could fetch stayed in place from April to August.
+
+## [0.1.4] - 2026-05-14
 - Fix: restore model selectors in `./run` and `./get` by preventing `.env` values from clobbering CLI selection state before the dialog flow starts.
 - Fix: make `./get` prompt for model, size, destination, and confirmation before downloading, while showing a meaningful archive label instead of a temporary filename in the progress dialog.
 - Fix: render selector dialogs through `/dev/tty` so interactive `dialog` menus remain visible when command stdout is captured or wrapped.


### PR DESCRIPTION
## What was broken

Tags `0.1.3` and `0.1.4` recorded `scripts/script-helpers` at `c11b42a1`, a commit that does not exist upstream. Anyone installing ai-runner from a release hit:

```
fatal: remote error: upload-pack: not our ref c11b42a1d5ab306cb018f8c12dde6071cab8cdc6
fatal: Fetched in submodule path 'scripts/script-helpers', but it did not
       contain c11b42a1... Direct fetching of that commit failed.
```

GitHub's API answers `422 No commit found for SHA` — not "unreachable", but never heard of it.

## Why it happened

It was **not** a history cleanup in script-helpers. Three checks rule that out:

- All 329 commits in script-helpers have matching author and committer dates. A rebase or `filter-repo` skews committer dates; there is no skew.
- History is intact to the root commit, `522f0c8` (2025-10-17).
- `production` is what `.gitmodules` tracks, so a force-reset of it was the obvious suspect. The workflow in force on 2026-04-09 used `git merge --ff-only` and a plain `git push`. It cannot strand an old tip.

The pin entered via `5a0f33e` (2026-04-09), *"fix: restore interactive model selection for run and get"* — a feature commit that swept the submodule bump in alongside `get.sh`, `run.sh` and `include.sh` changes, rather than a deliberate `chore(submodule)` bump like `796c77f` before it. script-helpers has no commits at all between 2026-03-25 and 2026-04-11, and the pin lands inside that hole.

So the commit was never merged into any surviving ref: committed in the submodule working tree, the parent repo pushed, the submodule commit not. Nothing was destroyed.

## What this PR does

- Pins `scripts/script-helpers` to the published **0.22.0** tag (`33fad65`). A published tag cannot quietly vanish the way an unpushed working-tree commit did, and it is the same commit `production` currently points at, which is what `.gitmodules` tracks.
- Adds `.github/workflows/submodules.yml`, which checks out submodules on every PR. Nothing in CI touched them before, which is how a pin no consumer could fetch survived from April to August. The job runs `git submodule update --init --recursive`, reproducing exactly what a consumer does rather than approximating it.
- Dates the `0.1.4` changelog heading, which still said `Unreleased` although the tag was cut on 2026-05-14.

## Verification

```
tag 0.1.4  git submodule update --init --recursive -> exit 128   (before)
main       git submodule update --init --recursive -> exit 0     (after fix on main)
release/0.1.5 recursive clone                      -> exit 0
```

Every helper ai-runner calls was checked against the new pin; the 0.12.0 → 0.22.0 jump removes nothing this repo uses. ShellCheck was not run locally (not installed on this machine); CI enforces it.

## Known issue this does NOT fix

`run.sh` and `get.sh` call `dialog_run`, `dialog_capture` and `dialog_has_tty`. Those three functions are defined **nowhere** — not in this repo, and not in any reachable commit of script-helpers' entire history:

```
$ source scripts/include.sh
print_info:     defined
dialog_run:     NOT DEFINED
dialog_capture: NOT DEFINED
dialog_has_tty: NOT DEFINED
```

They were almost certainly added by the same lost commit `c11b42a`, which is why `5a0f33e` introduced the calls and bumped the pin together. So the interactive paths in `./run` and `./get` are broken on `main`, `0.1.3` and `0.1.4` regardless of which fetchable commit the submodule points at.

This PR deliberately does not address that: restoring the three helpers means reimplementing them upstream in script-helpers and cutting a new tag, which is a separate change in a separate repository.

## Tagging

Merging this creates tag `0.1.5` automatically — `auto-tag-release.yml` derives the version from the merged `release/X.Y.Z` branch name.
