### PR TITLE
docs: add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,10 @@ Run:
 source .env
 ollama show --modelfile $MODEL
 ```
+
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/ai-runner.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
Adds the daily clone-traffic chart to the README.